### PR TITLE
Allow jms serializer v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
   fast_finish: true
   include:
     - php: '7.2'
+      env: TARGET=unit COMPOSER_FLAGS='--prefer-lowest'
+    - php: '7.2'
       env: TARGET=e2e
     - php: '7.2'
       env: TARGET=coverage
@@ -47,7 +49,7 @@ before_install:
     fi
 
 install:
-  - composer install
+  - composer update ${COMPOSER_FLAGS}
 
 script:
   - make ${TARGET}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "jms/serializer": "^2.1",
+        "jms/serializer": "^2.1 || ^3.0",
         "symfony/messenger": "^4.2"
     },
     "require-dev": {

--- a/src/Resources/config/serializer/JMS.Serializer.Context.xml
+++ b/src/Resources/config/serializer/JMS.Serializer.Context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="JMS\Serializer\Context">
+    <class name="JMS\Serializer\Context" exclusion-policy="ALL">
         <property name="attributes" type="array" expose="true"/>
         <property name="initialized" type="boolean" expose="true"/>
         <property name="format" type="string" expose="true"/>

--- a/src/Resources/config/serializer/JMS.Serializer.DeserializationContext.xml
+++ b/src/Resources/config/serializer/JMS.Serializer.DeserializationContext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="JMS\Serializer\DeserializationContext">
+    <class name="JMS\Serializer\DeserializationContext" exclusion-policy="ALL">
         <property name="depth" type="integer" expose="true"/>
     </class>
 </serializer>

--- a/src/Resources/config/serializer/JMS.Serializer.SerializationContext.xml
+++ b/src/Resources/config/serializer/JMS.Serializer.SerializationContext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="JMS\Serializer\SerializationContext">
+    <class name="JMS\Serializer\SerializationContext" exclusion-policy="ALL">
         <property name="serializeNull" type="boolean" expose="true"/>
     </class>
 </serializer>

--- a/src/Resources/config/serializer/KunicMarko.JMSMessengerAdapter.Stamp.DeserializationContextStamp.xml
+++ b/src/Resources/config/serializer/KunicMarko.JMSMessengerAdapter.Stamp.DeserializationContextStamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="KunicMarko\JMSMessengerAdapter\Stamp\DeserializationContextStamp">
+    <class name="KunicMarko\JMSMessengerAdapter\Stamp\DeserializationContextStamp" exclusion-policy="ALL">
         <property name="context" type="JMS\Serializer\DeserializationContext" expose="true" />
     </class>
 </serializer>

--- a/src/Resources/config/serializer/KunicMarko.JMSMessengerAdapter.Stamp.SerializationContextStamp.xml
+++ b/src/Resources/config/serializer/KunicMarko.JMSMessengerAdapter.Stamp.SerializationContextStamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="KunicMarko\JMSMessengerAdapter\Stamp\SerializationContextStamp">
+    <class name="KunicMarko\JMSMessengerAdapter\Stamp\SerializationContextStamp" exclusion-policy="ALL">
         <property name="context" type="JMS\Serializer\SerializationContext" expose="true" />
     </class>
 </serializer>

--- a/src/Resources/config/serializer/Symfony.Component.Messenger.Stamp.ValidationStamp.xml
+++ b/src/Resources/config/serializer/Symfony.Component.Messenger.Stamp.ValidationStamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="Symfony\Component\Messenger\Stamp\ValidationStamp">
+    <class name="Symfony\Component\Messenger\Stamp\ValidationStamp" exclusion-policy="ALL">
         <property name="groups" type="array" expose="true" />
     </class>
 </serializer>


### PR DESCRIPTION
- [x] fix XML metadata configs setting by using an explicit exclusion policy (before as buggy as the default if to serialize all props)
- [x] allow jms/serializer 3.x
- [x] run the tests with the minimum requirements
