### PR TITLE
Fixed class name in FlattenException serializer configuration

### DIFF
--- a/src/Resources/config/serializer/Symfony.Component.Debug.Exception.FlattenException.xml
+++ b/src/Resources/config/serializer/Symfony.Component.Debug.Exception.FlattenException.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="Symfony\Component\Messenger\Stamp\RedeliveryStamp" exclusion-policy="ALL">
+    <class name="Symfony\Component\Debug\Exception\FlattenException" exclusion-policy="ALL">
         <property name="message" type="string" expose="true" />
         <property name="code" type="int" expose="true" />
         <property name="traceAsString" type="string" expose="true" />


### PR DESCRIPTION
Hi @kunicmarko20 . I accidentally introduced a bug into the last PR, with the class name not matching the type of the exception class.