### PR TITLE
Added missing properties to Symfonys FlattenException.

### DIFF
--- a/src/Resources/config/serializer/Symfony.Component.ErrorHandler.Exception.FlattenException.xml
+++ b/src/Resources/config/serializer/Symfony.Component.ErrorHandler.Exception.FlattenException.xml
@@ -3,11 +3,15 @@
     <class name="Symfony\Component\ErrorHandler\Exception\FlattenException" exclusion-policy="ALL">
         <property name="message" type="string" expose="true" />
         <property name="code" type="int" expose="true" />
+        <property name="previous" type="Throwable" expose="true" />
+        <property name="trace" type="array" expose="true" />
         <property name="traceAsString" type="string" expose="true" />
         <property name="class" type="string" expose="true" />
-        <property name="statusCode" type="string" expose="true" />
+        <property name="statusCode" type="int" expose="true" />
+        <property name="statusText" type="string" expose="true" />
         <property name="headers" type="array" expose="true" />
         <property name="file" type="string" expose="true" />
         <property name="line" type="int" expose="true" />
+        <property name="asString" type="string" expose="true" />
     </class>
 </serializer>


### PR DESCRIPTION
Hey there,
me again :)
I am currently working in Symfony 5.1.2, with all its dependencies, and I got a problem of serializing a FlattenException because properties where missing from the serializer configuration.
I added them, can you plz have a look?
Thanks